### PR TITLE
force_text removed in Django 4.0 for force_str

### DIFF
--- a/osso/core/forms/widgets.py
+++ b/osso/core/forms/widgets.py
@@ -4,9 +4,9 @@ from django.forms import Select
 from django.utils.html import conditional_escape
 from django.forms.widgets import CheckboxInput, CheckboxSelectMultiple
 try:
-    from django.utils.encoding import force_text
+    from django.utils.encoding import force_str
 except ImportError:
-    from django.utils.encoding import force_unicode as force_text
+    from django.utils.encoding import force_text as force_str
 from django.utils.safestring import mark_safe
 
 
@@ -42,7 +42,7 @@ class CheckboxSelectMultipleWithJS(CheckboxSelectMultiple):
         final_attrs = self.build_attrs(attrs)
         output = []
         # Normalize to strings
-        str_values = set([force_text(v) for v in value])
+        str_values = set([force_str(v) for v in value])
         for i, (option_value, option_label) in enumerate(chain(self.choices,
                                                                choices)):
             # If an ID attribute was given, add a numeric index as a suffix,
@@ -56,9 +56,9 @@ class CheckboxSelectMultipleWithJS(CheckboxSelectMultiple):
 
             cb = CheckboxInput(final_attrs,
                                check_test=(lambda value: value in str_values))
-            option_value = force_text(option_value)
+            option_value = force_str(option_value)
             rendered_cb = cb.render(name, option_value, renderer=renderer)
-            option_label = conditional_escape(force_text(option_label))
+            option_label = conditional_escape(force_str(option_label))
             output.append('<label%s style="display:block;">%s %s</label>' %
                           (label_for, rendered_cb, option_label))
 

--- a/osso/core/forms/widgets.py
+++ b/osso/core/forms/widgets.py
@@ -3,10 +3,7 @@ from itertools import chain
 from django.forms import Select
 from django.utils.html import conditional_escape
 from django.forms.widgets import CheckboxInput, CheckboxSelectMultiple
-try:
-    from django.utils.encoding import force_text
-except ImportError:
-    from django.utils.encoding import force_unicode as force_text
+from django.utils.encoding import force_str
 from django.utils.safestring import mark_safe
 
 
@@ -42,7 +39,7 @@ class CheckboxSelectMultipleWithJS(CheckboxSelectMultiple):
         final_attrs = self.build_attrs(attrs)
         output = []
         # Normalize to strings
-        str_values = set([force_text(v) for v in value])
+        str_values = set([force_str(v) for v in value])
         for i, (option_value, option_label) in enumerate(chain(self.choices,
                                                                choices)):
             # If an ID attribute was given, add a numeric index as a suffix,
@@ -56,9 +53,9 @@ class CheckboxSelectMultipleWithJS(CheckboxSelectMultiple):
 
             cb = CheckboxInput(final_attrs,
                                check_test=(lambda value: value in str_values))
-            option_value = force_text(option_value)
+            option_value = force_str(option_value)
             rendered_cb = cb.render(name, option_value, renderer=renderer)
-            option_label = conditional_escape(force_text(option_label))
+            option_label = conditional_escape(force_str(option_label))
             output.append('<label%s style="display:block;">%s %s</label>' %
                           (label_for, rendered_cb, option_label))
 

--- a/osso/core/templatetags/js.py
+++ b/osso/core/templatetags/js.py
@@ -2,10 +2,7 @@
 from json import JSONEncoder, dumps
 
 from django.template import Library
-try:
-    from django.utils.encoding import force_text
-except ImportError:
-    from django.utils.encoding import force_unicode as force_text
+from django.utils.encoding import force_str
 from django.utils.functional import Promise
 
 register = Library()
@@ -14,7 +11,7 @@ register = Library()
 class _JSONEncoder(JSONEncoder):
     def default(self, obj):
         if isinstance(obj, Promise):
-            return force_text(obj)
+            return force_str(obj)
         return obj
 
 

--- a/osso/core/views.py
+++ b/osso/core/views.py
@@ -3,10 +3,7 @@ from django.conf import settings
 from django.core.mail import mail_admins
 from django.http import HttpResponse, HttpResponseServerError
 from django.template.loader import render_to_string
-try:
-    from django.utils.encoding import force_text
-except ImportError:
-    from django.utils.encoding import force_unicode as force_text
+from django.utils.encoding import force_str
 from django.utils.html import escape
 
 
@@ -91,7 +88,7 @@ def simple_form_view(request, form_class, form_kwargs={}, heading='Form',
             return httpresponse_ok(message='', saved=return_value)
         if mail_on_fail:
             mail_admins(
-                'Invalid input on "%s" form' % (force_text(heading),),
+                'Invalid input on "%s" form' % (force_str(heading),),
                 ('Form validation failed for form %s with kwargs %r.\n\n'
                  'Host: %s\nPath: %s\nRemoteAddr: %s\n\nData: %r\n\n'
                  'Errors: %r\n') %
@@ -108,12 +105,11 @@ def simple_form_view(request, form_class, form_kwargs={}, heading='Form',
 
 
 def _html(title, body):
-    return '''<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" \
-"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+    return '''<!DOCTYPE html>
+<html lang="en">
 <head>
   <title>%(title)s</title>
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <meta charset="utf-8">
 </head>
 <body>
   <h1>%(title)s</h1>


### PR DESCRIPTION
Django 4.0 removes force_text() (which is an alias of force_str()) from the django.utils.encoding module.